### PR TITLE
Explain how to enable in project settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,12 @@ included in Django 1.6.
 Quick usage
 -----------
 
+Change TEST_RUNNER in your project settings to enable django-discoverage as the
+project test runner:
+
+    -TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+    +TEST_RUNNER = 'discoverage.runner.DiscoverageRunner'
+
 To run the tests, type:
 
     ./manage.py test [options] [appname ...]


### PR DESCRIPTION
The readme doesn't explain how to enable a replacement Django test runner. I'm working on an existing project and I couldn't figure out why discoverage wasn't working. It was installed in the requirements and configured in some tests, but there were no results. Oh! The previous developer never actually enabled it. Ha! This minor readme change should make the installation process more clear.
